### PR TITLE
Add libi2c-dev build dependency

### DIFF
--- a/lib/i2c/include/linux_i2c_communicator/LinuxI2cCommunicator.h
+++ b/lib/i2c/include/linux_i2c_communicator/LinuxI2cCommunicator.h
@@ -1,6 +1,7 @@
 #ifndef __LINUXI2CCOMMUNICATOR_H__
 #define __LINUXI2CCOMMUNICATOR_H__
 
+#include <chrono>
 #include "I2cCommunicator.h"
 
 class LinuxI2cCommunicator final : public I2cCommunicator {
@@ -14,6 +15,8 @@ class LinuxI2cCommunicator final : public I2cCommunicator {
  private:
   void reportError(int error);
   int file_;
+  std::chrono::steady_clock::time_point last_error_time_ = std::chrono::steady_clock::now();
+  static constexpr std::chrono::seconds error_interval_{5}; // Print error every 5 seconds
 };
 
 #endif  // __LINUXI2CCOMMUNICATOR_H__

--- a/lib/i2c/src/LinuxI2cCommunicator.cpp
+++ b/lib/i2c/src/LinuxI2cCommunicator.cpp
@@ -9,8 +9,12 @@ extern "C" {
 #include <unistd.h>
 }
 
+#include <chrono>
 #include <iostream>
 #include <string>
+
+// Define the static member
+constexpr std::chrono::seconds LinuxI2cCommunicator::error_interval_;
 
 LinuxI2cCommunicator::LinuxI2cCommunicator(int bus_number)
 {
@@ -44,5 +48,9 @@ char LinuxI2cCommunicator::getFile() { return file_; }
 
 void LinuxI2cCommunicator::reportError(int error)
 {
-  std::cerr << "Error! Errno: " << strerror(error) << std::endl;
+  auto now = std::chrono::steady_clock::now();
+  if (now - last_error_time_ >= error_interval_) {
+    std::cerr << "Error! Errno: " << strerror(error) << std::endl;
+    last_error_time_ = now;
+  }
 }

--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>libi2c-dev</build_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
The libi2c-dev build-time dependency is added to `package.xml`. It is required by the source file `lib/i2c/src/LinuxI2cCommunicator.cpp`. This PR fixes the missing dependency.

```c
#include <i2c/smbus.h>
```